### PR TITLE
ref(cypress): modifies createDefaultTodos command to use consistent syntax

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -18,7 +18,7 @@ Cypress.Commands.add('createDefaultTodos', () => {
     .type(`${TODO_ITEM_THREE}{enter}`, { log: false })
 
   cy.get('.todo-list li', { log: false })
-    .then(function ($listItems) {
-      cmd.set({ $el: $listItems }).snapshot().end()
+    .then(listItems => {
+      cmd.set({ el: listItems }).snapshot().end()
     })
 })


### PR DESCRIPTION
I noticed this inconsistency when reviewing the notion documents that are referencing this command. I think there is value in being consistent, especially from the resources we are selling to the community as best practices. 